### PR TITLE
Add settings, log window, and champion upgrade calculator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.rslbot</groupId>
+    <artifactId>rsl-bot</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/rslbot/ChampionUpgrade.java
+++ b/src/main/java/rslbot/ChampionUpgrade.java
@@ -1,0 +1,35 @@
+package rslbot;
+
+/**
+ * Utility for computing how many 1★ champions are required to create
+ * a champion of a given rank. In the game, promoting a champion to the
+ * next rank requires feeding it a number of fodder champions equal to
+ * its current rank, and each fodder champion must itself be ranked up
+ * in the same way. This results in a factorial growth in the amount of
+ * fodder needed.
+ */
+public class ChampionUpgrade {
+
+    /**
+     * Returns the total number of 1★ champions required to build a single
+     * champion of the supplied rank.
+     *
+     * @param rank target rank (must be positive)
+     * @return number of base 1★ champions needed
+     */
+    public static int championsNeeded(int rank) {
+        if (rank < 1) {
+            throw new IllegalArgumentException("rank must be positive");
+        }
+        int total = 1;
+        for (int i = 2; i <= rank; i++) {
+            total *= i; // factorial growth
+        }
+        return total;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("To upgrade 3★ → " + championsNeeded(3) + " fodders");
+        System.out.println("To upgrade 4★ → " + championsNeeded(4) + " fodders");
+    }
+}

--- a/src/main/java/rslbot/LogWindow.java
+++ b/src/main/java/rslbot/LogWindow.java
@@ -1,0 +1,68 @@
+package rslbot;
+
+import javax.swing.*;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+/**
+ * Simple window that displays log messages redirected from System.out/err.
+ */
+public class LogWindow extends JFrame {
+    private static LogWindow instance;
+    private final JTextArea area = new JTextArea();
+
+    private LogWindow() {
+        super("RSL Bot Log");
+        setSize(500, 300);
+        setLocationRelativeTo(null);
+        area.setEditable(false);
+        add(new JScrollPane(area));
+    }
+
+    public static synchronized LogWindow getInstance() {
+        if (instance == null) {
+            instance = new LogWindow();
+        }
+        return instance;
+    }
+
+    private void appendLine(String text) {
+        SwingUtilities.invokeLater(() -> {
+            area.append(text + System.lineSeparator());
+            area.setCaretPosition(area.getDocument().getLength());
+        });
+    }
+
+    /**
+     * Displays the log window and redirects standard output streams to it.
+     */
+    public static void install() {
+        LogWindow log = getInstance();
+        log.setVisible(true);
+        PrintStream ps = new PrintStream(new TextAreaOutputStream(log), true);
+        System.setOut(ps);
+        System.setErr(ps);
+    }
+
+    private static class TextAreaOutputStream extends OutputStream {
+        private final LogWindow window;
+        private final StringBuilder buffer = new StringBuilder();
+
+        TextAreaOutputStream(LogWindow window) {
+            this.window = window;
+        }
+
+        @Override
+        public void write(int b) {
+            if (b == '\r') {
+                return;
+            }
+            if (b == '\n') {
+                window.appendLine(buffer.toString());
+                buffer.setLength(0);
+            } else {
+                buffer.append((char) b);
+            }
+        }
+    }
+}

--- a/src/main/java/rslbot/SettingsWindow.java
+++ b/src/main/java/rslbot/SettingsWindow.java
@@ -1,0 +1,57 @@
+package rslbot;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Simple Swing window that provides a few configuration options
+ * similar to those found in the RSLHelper application.
+ */
+public class SettingsWindow extends JFrame {
+    private final JCheckBox autoSell;
+    private final JCheckBox enableOcr;
+    private final JSpinner runCount;
+
+    public SettingsWindow() {
+        super("RSL Bot Settings");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setLayout(new BorderLayout());
+
+        // Settings controls
+        autoSell = new JCheckBox("Auto sell gear");
+        enableOcr = new JCheckBox("Enable OCR");
+        runCount = new JSpinner(new SpinnerNumberModel(10, 1, 1000, 1));
+
+        JPanel center = new JPanel(new GridLayout(0, 1));
+        center.add(autoSell);
+        center.add(enableOcr);
+        center.add(new JLabel("Runs per session:"));
+        center.add(runCount);
+
+        JButton save = new JButton("Save");
+        save.addActionListener(e -> saveSettings());
+
+        add(center, BorderLayout.CENTER);
+        add(save, BorderLayout.SOUTH);
+
+        pack();
+        setLocationRelativeTo(null); // center on screen
+    }
+
+    private void saveSettings() {
+        // In a full implementation, settings would be persisted to disk.
+        // For now, just dump to console.
+        System.out.println("Settings saved:");
+        System.out.println("  Auto sell gear: " + autoSell.isSelected());
+        System.out.println("  Enable OCR: " + enableOcr.isSelected());
+        System.out.println("  Runs per session: " + runCount.getValue());
+    }
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            LogWindow.install();
+            new SettingsWindow().setVisible(true);
+            System.out.println("Settings window displayed");
+        });
+    }
+}

--- a/src/test/java/rslbot/ChampionUpgradeTest.java
+++ b/src/test/java/rslbot/ChampionUpgradeTest.java
@@ -1,0 +1,20 @@
+package rslbot;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChampionUpgradeTest {
+
+    @Test
+    void factorialGrowth() {
+        assertEquals(1, ChampionUpgrade.championsNeeded(1));
+        assertEquals(2, ChampionUpgrade.championsNeeded(2));
+        assertEquals(6, ChampionUpgrade.championsNeeded(3));
+        assertEquals(24, ChampionUpgrade.championsNeeded(4));
+    }
+
+    @Test
+    void invalidRankThrows() {
+        assertThrows(IllegalArgumentException.class, () -> ChampionUpgrade.championsNeeded(0));
+    }
+}


### PR DESCRIPTION
## Summary
- provide Swing-based settings window with options for auto selling gear, enabling OCR, and run count
- add factorial-based champion upgrade calculator with validation
- cover champion upgrade logic with JUnit tests
- introduce Swing log window that captures System.out/err output

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7592fa6e48330965fde318d2b46ca